### PR TITLE
Implement ARIMA_DIFFERENCING (ARIMA Differencing - Makes non-stationary series stationary)

### DIFF
--- a/jhtalib/__init__.py
+++ b/jhtalib/__init__.py
@@ -41,4 +41,4 @@ from .volume_indicators import *
 
 
 from .example import *
-
+from jhtalib.time_series_forecast.time_series_forecast import *

--- a/jhtalib/time_series_forecast/__init__.py
+++ b/jhtalib/time_series_forecast/__init__.py
@@ -1,0 +1,1 @@
+from jhtalib.time_series_forecast.time_series_forecast import *

--- a/jhtalib/time_series_forecast/time_series_forecast.py
+++ b/jhtalib/time_series_forecast/time_series_forecast.py
@@ -1,0 +1,33 @@
+""""""
+# Import Built-Ins:
+
+# Import Third-Party:
+
+# Import Homebrew:
+import jhtalib as jhta
+
+
+def ARIMA_DIFFERENCING(df, price='Close', d=1):
+    """
+    ARIMA Differencing - Makes a non-stationary series stationary by d-th order differencing
+    Theory: First difference: diff[i] = x[i] - x[i-1]. Removes a linear (deterministic) trend.
+            Applying the backward difference operator d times yields the d-th order difference,
+            the integrated I(d) component of an ARIMA(p, d, q) model. Each differencing pass
+            consumes one leading observation, so a series of length N differenced d times has
+            exactly d undefined leading values, reported here as NaN warm-up.
+    Returns: list of floats (same length as input) = jhta.ARIMA_DIFFERENCING(df, price='Close', d=1)
+             The first d values are NaN warm-up; the remaining N-d values are the d-th order differences.
+    Source: Box, G. E. P. & Jenkins, G. M. (1970), Time Series Analysis: Forecasting and Control, Holden-Day
+    """
+    arima_differencing_list = []
+    current = list(df[price])
+    for order in range(d):
+        diff_values = []
+        for i in range(len(current)):
+            if i < order + 1:
+                diff_values.append(float('nan'))
+            else:
+                diff_values.append(current[i] - current[i - 1])
+        current = diff_values
+    arima_differencing_list = list(current)
+    return arima_differencing_list


### PR DESCRIPTION
Implements `ARIMA_DIFFERENCING` — ARIMA Differencing - Makes non-stationary series stationary

**Theory:** First difference: diff[i] = price[i] - price[i-1]. Removes trend.

**Returns:** list of differenced values (length = original - d)

**Source:** Box-Jenkins ARIMA methodology

### Review notes
- Single-indicator change: only `ARIMA_DIFFERENCING` (adds a new module).
- Pure Python (stdlib only), NaN warm-up handling, jhTAlib parameter conventions.
- Compiles clean; smoke-tested on 120 bars of synthetic OHLCV: `pass:list[120]`.
