### PR TITLE
Implement DX (Directional Movement Index - Component of ADX)

### DIFF
--- a/jhtalib/momentum_indicators/momentum_indicators.py
+++ b/jhtalib/momentum_indicators/momentum_indicators.py
@@ -64,10 +64,66 @@ def CMO(df, n, price='Close'):
     Chande Momentum Oscillator
     """
 
-def DX(df, n):
+def DX(df, n, high='High', low='Low', close='Close'):
     """
-    Directional Movement Index
+    Directional Movement Index - the raw directional component of Wilder's ADX.
+    Theory: True Range, +DM and -DM are Wilder-smoothed (first value = n-bar sum,
+            then smoothed[i] = smoothed[i-1] - smoothed[i-1] / n + value[i]).
+            +DI = 100 * smoothed(+DM) / smoothed(TR),
+            -DI = 100 * smoothed(-DM) / smoothed(TR),
+            DX  = 100 * |+DI - -DI| / (+DI + -DI), on a 0-100 scale.
+            +DM/-DM per bar: up = high[i] - high[i-1], down = low[i-1] - low[i];
+            +DM = up if (up > down and up > 0) else 0; -DM = down if (down > up
+            and down > 0) else 0. This is the DX that ADX smooths, and matches the
+            +DI/-DI definition cited in the ADXR docstring.
+    Returns: list of floats (DX values 0-100, NaN during the warm-up before index n)
+    Source: J. Welles Wilder Jr., New Concepts in Technical Trading Systems (1978)
     """
+    highs = df[high]
+    lows = df[low]
+    closes = df[close]
+    length = len(closes)
+
+    # True Range, +DM, -DM (defined from the second bar onward)
+    tr_list = [float('NaN')]
+    pdm_list = [float('NaN')]
+    mdm_list = [float('NaN')]
+    for i in range(1, length):
+        tr = max(highs[i] - lows[i], abs(highs[i] - closes[i - 1]), abs(lows[i] - closes[i - 1]))
+        up_move = highs[i] - highs[i - 1]
+        down_move = lows[i - 1] - lows[i]
+        pdm = up_move if (up_move > down_move and up_move > 0) else .0
+        mdm = down_move if (down_move > up_move and down_move > 0) else .0
+        tr_list.append(tr)
+        pdm_list.append(pdm)
+        mdm_list.append(mdm)
+
+    # Wilder smoothing of TR, +DM, -DM, then DX from the resulting +DI/-DI
+    dx_list = [float('NaN')] * length
+    smoothed_tr = .0
+    smoothed_pdm = .0
+    smoothed_mdm = .0
+    for i in range(1, length):
+        if i < n:
+            continue
+        if i == n:
+            smoothed_tr = sum(tr_list[1:n + 1])
+            smoothed_pdm = sum(pdm_list[1:n + 1])
+            smoothed_mdm = sum(mdm_list[1:n + 1])
+        else:
+            smoothed_tr = smoothed_tr - smoothed_tr / n + tr_list[i]
+            smoothed_pdm = smoothed_pdm - smoothed_pdm / n + pdm_list[i]
+            smoothed_mdm = smoothed_mdm - smoothed_mdm / n + mdm_list[i]
+        if smoothed_tr != 0:
+            pdi = 100 * smoothed_pdm / smoothed_tr
+            mdi = 100 * smoothed_mdm / smoothed_tr
+        else:
+            pdi = .0
+            mdi = .0
+        di_sum = pdi + mdi
+        dx_list[i] = 100 * abs(pdi - mdi) / di_sum if di_sum != 0 else .0
+
+    return dx_list
 
 def MACD(df, price='Close'):
     """


### PR DESCRIPTION
Implements `DX` — Directional Movement Index - Component of ADX

**Theory:** DX = 100 * |+DI - -DI| / (+DI + -DI). Measures directional movement intensity.

**Returns:** list of floats (DX values, NaN for periods < n)

**Source:** J. Welles Wilder Jr. - New Concepts in Technical Trading Systems

### Review notes
- Single-indicator change: only `DX` (implements the existing stub in place).
- Pure Python (stdlib only), NaN warm-up handling, jhTAlib parameter conventions.
- Compiles clean; smoke-tested on 120 bars of synthetic OHLCV: `pass:list[120]`.
