### PR TITLE
Implement STANDARD_DEVIATION (Standard Deviation - Volatility measurement)

### DIFF
--- a/jhtalib/__init__.py
+++ b/jhtalib/__init__.py
@@ -41,4 +41,4 @@ from .volume_indicators import *
 
 
 from .example import *
-
+from jhtalib.statistical_indicators.statistical_indicators import *

--- a/jhtalib/statistical_indicators/__init__.py
+++ b/jhtalib/statistical_indicators/__init__.py
@@ -1,0 +1,1 @@
+from jhtalib.statistical_indicators.statistical_indicators import *

--- a/jhtalib/statistical_indicators/statistical_indicators.py
+++ b/jhtalib/statistical_indicators/statistical_indicators.py
@@ -1,0 +1,36 @@
+""""""
+# Import Built-Ins:
+import math
+
+# Import Third-Party:
+
+# Import Homebrew:
+import jhtalib as jhta
+
+
+def STANDARD_DEVIATION(df, n=20, price='Close'):
+    """
+    Standard Deviation - Volatility measurement
+    Theory: StdDev = √(Σ(xi - mean)² / n). Measures price dispersion.
+            Higher StdDev = more volatile. Used in Bollinger Bands, VIX-like metrics.
+    Returns: list of floats (standard deviation values, NaN for periods < n)
+    Source: Statistical volatility analysis
+    """
+    result = []
+
+    for i in range(len(df[price])):
+        if i + 1 < n:
+            result.append(float('NaN'))
+            continue
+
+        start = i + 1 - n
+        end = i + 1
+        prices = df[price][start:end]
+
+        mean_price = sum(prices) / n
+        variance = sum((p - mean_price) ** 2 for p in prices) / n
+        stddev = math.sqrt(variance)
+
+        result.append(stddev)
+
+    return result


### PR DESCRIPTION
Implements `STANDARD_DEVIATION` — Standard Deviation - Volatility measurement

**Theory:** StdDev = √(Σ(xi - mean)² / n). Measures price dispersion.

**Returns:** list of floats (standard deviation values, NaN for periods < n)

**Source:** Statistical volatility analysis

### Review notes
- Single-indicator change: only `STANDARD_DEVIATION` (adds a new module).
- Pure Python (stdlib only), NaN warm-up handling, jhTAlib parameter conventions.
- Compiles clean; smoke-tested on 120 bars of synthetic OHLCV: `pass:list[120]`.
