### PR TITLE
Implement SUM_SQUARED_ERRORS (Sum of Squared Errors - Total variance from mean in period)

### DIFF
--- a/jhtalib/__init__.py
+++ b/jhtalib/__init__.py
@@ -41,4 +41,4 @@ from .volume_indicators import *
 
 
 from .example import *
-
+from jhtalib.statistical_indicators.statistical_indicators import *

--- a/jhtalib/statistical_indicators/__init__.py
+++ b/jhtalib/statistical_indicators/__init__.py
@@ -1,0 +1,1 @@
+from jhtalib.statistical_indicators.statistical_indicators import *

--- a/jhtalib/statistical_indicators/statistical_indicators.py
+++ b/jhtalib/statistical_indicators/statistical_indicators.py
@@ -1,0 +1,34 @@
+""""""
+# Import Built-Ins:
+
+# Import Third-Party:
+
+# Import Homebrew:
+import jhtalib as jhta
+
+
+def SUM_SQUARED_ERRORS(df, n=20, price='Close'):
+    """
+    Sum of Squared Errors - Total variance from mean in period
+    Theory: SSE = Σ(xi - mean)². Measures total squared deviations from average.
+            Higher SSE = more volatility/variance in period. Used in regression analysis.
+    Returns: list of floats (SSE values, NaN for periods < n)
+    Source: Statistical regression analysis
+    """
+    result = []
+
+    for i in range(len(df[price])):
+        if i + 1 < n:
+            result.append(float('NaN'))
+            continue
+
+        start = i + 1 - n
+        end = i + 1
+        prices = df[price][start:end]
+
+        mean_price = sum(prices) / n
+        sse = sum((p - mean_price) ** 2 for p in prices)
+
+        result.append(sse)
+
+    return result


### PR DESCRIPTION
Implements `SUM_SQUARED_ERRORS` — Sum of Squared Errors - Total variance from mean in period

**Theory:** SSE = Σ(xi - mean)². Measures total squared deviations from average.

**Returns:** list of floats (SSE values, NaN for periods < n)

**Source:** Statistical regression analysis

### Review notes
- Single-indicator change: only `SUM_SQUARED_ERRORS` (adds a new module).
- Pure Python (stdlib only), NaN warm-up handling, jhTAlib parameter conventions.
- Compiles clean; smoke-tested on 120 bars of synthetic OHLCV: `pass:list[120]`.
