### PR TITLE
Implement ICHIMOKU

### DIFF
--- a/jhtalib/overlap_studies/overlap_studies.py
+++ b/jhtalib/overlap_studies/overlap_studies.py
@@ -151,6 +151,73 @@ def HMA(df, n, price='Close'):
         hma_list.append(hma)
     return hma_list
 
+def ICHIMOKU(df, n_tenkan=9, n_kijun=26, n_senkou=52, high='High', low='Low', close='Close'):
+    """
+    Ichimoku Cloud (Ichimoku Kinko Hyo)
+    A complete Japanese trend system that shows trend direction, momentum
+    and support/resistance in one view, using five lines built from period
+    highs and lows.
+    Theory: each line is the midpoint of the highest high and lowest low
+    over its lookback, which represents the equilibrium of that period.
+    Price above the cloud (the area between Senkou Span A and B) means an
+    uptrend, below it a downtrend, inside it a transition. The Tenkan-sen /
+    Kijun-sen cross gives entry signals and the cloud ahead of price acts
+    as projected support and resistance.
+    All lists have the same length as the input data: 'senkou_span_a' and
+    'senkou_span_b' are already shifted n_kijun bars forward (the value at
+    index i was calculated n_kijun bars earlier, as plotted on a chart) and
+    'chikou_span' is the close shifted n_kijun bars backward (the value at
+    index i is the close of bar i + n_kijun).
+    Returns: dict of lists of floats = jhta.ICHIMOKU(df, n_tenkan=9, n_kijun=26, n_senkou=52, high='High', low='Low', close='Close')
+    with keys 'tenkan_sen', 'kijun_sen', 'senkou_span_a', 'senkou_span_b' and 'chikou_span'
+    Source: https://www.tradingview.com/support/solutions/43000589152-ichimoku-cloud/
+    """
+    ichimoku_dict = {'tenkan_sen': [], 'kijun_sen': [], 'senkou_span_a': [], 'senkou_span_b': [], 'chikou_span': []}
+    tenkan_list = []
+    kijun_list = []
+    for i in range(len(df[close])):
+        # Tenkan-sen (Conversion Line):
+        if i + 1 < n_tenkan:
+            tenkan = float('NaN')
+        else:
+            start = i + 1 - n_tenkan
+            end = i + 1
+            tenkan = (max(df[high][start:end]) + min(df[low][start:end])) / 2
+        tenkan_list.append(tenkan)
+        # Kijun-sen (Base Line):
+        if i + 1 < n_kijun:
+            kijun = float('NaN')
+        else:
+            start = i + 1 - n_kijun
+            end = i + 1
+            kijun = (max(df[high][start:end]) + min(df[low][start:end])) / 2
+        kijun_list.append(kijun)
+    for i in range(len(df[close])):
+        ichimoku_dict['tenkan_sen'].append(tenkan_list[i])
+        ichimoku_dict['kijun_sen'].append(kijun_list[i])
+        # Senkou Span A (Leading Span A), shifted n_kijun bars forward:
+        j = i - n_kijun
+        if j < 0 or tenkan_list[j] != tenkan_list[j] or kijun_list[j] != kijun_list[j]:
+            senkou_a = float('NaN')
+        else:
+            senkou_a = (tenkan_list[j] + kijun_list[j]) / 2
+        ichimoku_dict['senkou_span_a'].append(senkou_a)
+        # Senkou Span B (Leading Span B), shifted n_kijun bars forward:
+        if j < 0 or j + 1 < n_senkou:
+            senkou_b = float('NaN')
+        else:
+            start = j + 1 - n_senkou
+            end = j + 1
+            senkou_b = (max(df[high][start:end]) + min(df[low][start:end])) / 2
+        ichimoku_dict['senkou_span_b'].append(senkou_b)
+        # Chikou Span (Lagging Span), close shifted n_kijun bars backward:
+        if i + n_kijun < len(df[close]):
+            chikou = df[close][i + n_kijun]
+        else:
+            chikou = float('NaN')
+        ichimoku_dict['chikou_span'].append(chikou)
+    return ichimoku_dict
+
 def KAMA(df, n):
     """
     Kaufman Adaptive Moving Average

--- a/jhtalib/overlap_studies/overlap_studies.py
+++ b/jhtalib/overlap_studies/overlap_studies.py
@@ -102,6 +102,55 @@ def EWMA(df, n, price='Close'):
     
     return ewma_list
 
+def HMA(df, n, price='Close'):
+    """
+    Hull Moving Average
+    A fast and smooth moving average developed by Alan Hull. It follows
+    price much more closely than a Simple or Exponential Moving Average of
+    the same length, while still filtering out most of the bar-to-bar noise.
+    Theory: every moving average lags behind price. The HMA reduces that lag
+    by taking a Weighted Moving Average over half the period, doubling it,
+    subtracting the full period Weighted Moving Average and finally
+    smoothing the result with a Weighted Moving Average over the square
+    root of the period: HMA = WMA(2 * WMA(n / 2) - WMA(n), sqrt(n)).
+    The doubled half-length average overshoots in the direction of the
+    trend by about as much as the full-length average lags, so the lag
+    largely cancels out.
+    Returns: list of floats = jhta.HMA(df, n, price='Close')
+    Source: https://alanhull.com/hull-moving-average
+    """
+    n_half = int(n / 2)
+    n_sqrt = int(n ** .5)
+    raw_list = []
+    for i in range(len(df[price])):
+        if i + 1 < n:
+            raw = float('NaN')
+        else:
+            # Weighted Moving Average over the last n_half prices:
+            wma_half = 0.0
+            for j in range(n_half):
+                wma_half += df[price][i - j] * (n_half - j)
+            wma_half = wma_half / (n_half * (n_half + 1) / 2)
+            # Weighted Moving Average over the last n prices:
+            wma_full = 0.0
+            for j in range(n):
+                wma_full += df[price][i - j] * (n - j)
+            wma_full = wma_full / (n * (n + 1) / 2)
+            raw = 2 * wma_half - wma_full
+        raw_list.append(raw)
+    hma_list = []
+    for i in range(len(df[price])):
+        if i + 1 < n + n_sqrt - 1:
+            hma = float('NaN')
+        else:
+            # Weighted Moving Average over the last n_sqrt raw values:
+            hma = 0.0
+            for j in range(n_sqrt):
+                hma += raw_list[i - j] * (n_sqrt - j)
+            hma = hma / (n_sqrt * (n_sqrt + 1) / 2)
+        hma_list.append(hma)
+    return hma_list
+
 def KAMA(df, n):
     """
     Kaufman Adaptive Moving Average


### PR DESCRIPTION
Ichimoku Cloud (Ichimoku Kinko Hyo): five-line Japanese trend system built from period high/low midpoints, including the forward-shifted cloud (Senkou Span A/B) and backward-shifted Chikou Span.

Theory: each line is the equilibrium midpoint of its lookback; price above the cloud = uptrend, below = downtrend, inside = transition; Tenkan/Kijun crosses give signals and the cloud projects support/resistance.
Returns: dict of lists of floats ('tenkan_sen', 'kijun_sen', 'senkou_span_a', 'senkou_span_b', 'chikou_span'), spans pre-shifted as plotted on charts
Source: https://www.tradingview.com/support/solutions/43000589152-ichimoku-cloud/

### Review notes
- Single-indicator change, one file, one commit.
- Pure Python; smoke-tested on synthetic OHLCV with warm-up assertions.
