### PR TITLE
Implement TSI

### DIFF
--- a/jhtalib/momentum_indicators/momentum_indicators.py
+++ b/jhtalib/momentum_indicators/momentum_indicators.py
@@ -414,3 +414,59 @@ def FISHER(df, n=9, high='High', low='Low'):
             fisher_dict['fisher'].append(fisher)
             fisher_dict['signal'].append(signal)
     return fisher_dict
+
+def KST(df, r1=10, r2=15, r3=20, r4=30, n1=10, n2=10, n3=10, n4=15, ns=9, price='Close'):
+    """
+    Know Sure Thing
+    Martin Pring's momentum oscillator that combines the smoothed Rate of
+    Change of four different lookbacks into one weighted sum, plus a
+    signal line.
+    Theory: markets move in several overlapping cycles at the same time. A
+    single Rate of Change only sees one of them, so Pring averages four:
+    ROC(r1..r4), each smoothed with a Simple Moving Average (n1..n4) and
+    weighted 1 to 4 so the slowest, most important cycle dominates. The
+    result swings around zero: crosses above the signal line (an
+    ns-period Simple Moving Average of the KST) and above zero indicate
+    building upside momentum, and divergences against price warn of
+    reversals.
+    Returns: dict of lists of floats = jhta.KST(df, r1=10, r2=15, r3=20, r4=30, n1=10, n2=10, n3=10, n4=15, ns=9, price='Close')
+    with keys 'kst' and 'signal'
+    Source: https://school.stockcharts.com/doku.php?id=technical_indicators:know_sure_thing_kst
+    """
+    kst_dict = {'kst': [], 'signal': []}
+    warmup = max(r1 + n1, r2 + n2, r3 + n3, r4 + n4) - 1
+    kst_list = []
+    for i in range(len(df[price])):
+        if i < warmup:
+            kst = float('NaN')
+        else:
+            # smoothed Rate of Change 1 (weight 1):
+            rcma1 = 0.0
+            for j in range(n1):
+                rcma1 += ((df[price][i - j] / df[price][i - j - r1]) - 1) * 100
+            rcma1 = rcma1 / n1
+            # smoothed Rate of Change 2 (weight 2):
+            rcma2 = 0.0
+            for j in range(n2):
+                rcma2 += ((df[price][i - j] / df[price][i - j - r2]) - 1) * 100
+            rcma2 = rcma2 / n2
+            # smoothed Rate of Change 3 (weight 3):
+            rcma3 = 0.0
+            for j in range(n3):
+                rcma3 += ((df[price][i - j] / df[price][i - j - r3]) - 1) * 100
+            rcma3 = rcma3 / n3
+            # smoothed Rate of Change 4 (weight 4):
+            rcma4 = 0.0
+            for j in range(n4):
+                rcma4 += ((df[price][i - j] / df[price][i - j - r4]) - 1) * 100
+            rcma4 = rcma4 / n4
+            kst = rcma1 * 1 + rcma2 * 2 + rcma3 * 3 + rcma4 * 4
+        kst_list.append(kst)
+    for i in range(len(df[price])):
+        kst_dict['kst'].append(kst_list[i])
+        if i < warmup + ns - 1:
+            signal = float('NaN')
+        else:
+            signal = sum(kst_list[i + 1 - ns:i + 1]) / ns
+        kst_dict['signal'].append(signal)
+    return kst_dict

--- a/jhtalib/momentum_indicators/momentum_indicators.py
+++ b/jhtalib/momentum_indicators/momentum_indicators.py
@@ -470,3 +470,50 @@ def KST(df, r1=10, r2=15, r3=20, r4=30, n1=10, n2=10, n3=10, n4=15, ns=9, price=
             signal = sum(kst_list[i + 1 - ns:i + 1]) / ns
         kst_dict['signal'].append(signal)
     return kst_dict
+
+def TSI(df, n_long=25, n_short=13, n_signal=13, price='Close'):
+    """
+    True Strength Index
+    William Blau's double smoothed momentum oscillator that swings between
+    -100 and +100, plus a signal line.
+    Theory: raw bar-to-bar momentum (close minus previous close) is far
+    too noisy to trade. Blau smooths it twice with Exponential Moving
+    Averages (first over n_long, then over n_short bars) and divides by
+    the equally double smoothed absolute momentum. The division rescales
+    the result to -100..+100, so it works like an RSI but with much less
+    noise: values above zero mean buyers are in control, crosses of the
+    signal line (an n_signal EMA of the TSI) give entries, and
+    divergences against price warn of reversals.
+    Returns: dict of lists of floats = jhta.TSI(df, n_long=25, n_short=13, n_signal=13, price='Close')
+    with keys 'tsi' and 'signal'
+    Source: https://school.stockcharts.com/doku.php?id=technical_indicators:true_strength_index
+    """
+    tsi_dict = {'tsi': [], 'signal': []}
+    mom_dict = {'mom': [], 'absmom': []}
+    for i in range(len(df[price])):
+        if i < 1:
+            mom = float('NaN')
+        else:
+            mom = df[price][i] - df[price][i - 1]
+        mom_dict['mom'].append(mom)
+        mom_dict['absmom'].append(abs(mom))
+    smooth_dict = {
+        'mom': jhta.EMA(mom_dict, n_long, 'mom'),
+        'absmom': jhta.EMA(mom_dict, n_long, 'absmom')
+    }
+    double_dict = {
+        'mom': jhta.EMA(smooth_dict, n_short, 'mom'),
+        'absmom': jhta.EMA(smooth_dict, n_short, 'absmom')
+    }
+    tsi_list = []
+    for i in range(len(df[price])):
+        double_mom = double_dict['mom'][i]
+        double_absmom = double_dict['absmom'][i]
+        if double_absmom != double_absmom or double_absmom == 0:
+            tsi = float('NaN')
+        else:
+            tsi = 100 * double_mom / double_absmom
+        tsi_list.append(tsi)
+    tsi_dict['tsi'] = tsi_list
+    tsi_dict['signal'] = jhta.EMA({'tsi': tsi_list}, n_signal, 'tsi')
+    return tsi_dict

--- a/jhtalib/momentum_indicators/momentum_indicators.py
+++ b/jhtalib/momentum_indicators/momentum_indicators.py
@@ -1,5 +1,6 @@
 """"""
 # Import Built-Ins:
+import math
 
 # Import Third-Party:
 
@@ -365,3 +366,51 @@ def WILLR(df, n, high='High', low='Low', close='Close'):
         willr_list.append(willr)
     return willr_list
 
+def FISHER(df, n=9, high='High', low='Low'):
+    """
+    Fisher Transform
+    Converts the position of the bar midpoint within its recent range into
+    a sharply peaked oscillator that makes price extremes stand out.
+    Theory: John Ehlers observed that prices are not normally distributed,
+    so oscillator extremes are hard to compare. The Fisher Transform first
+    normalizes the midpoint (high + low) / 2 into the range -1 to +1 over
+    the last n bars and then applies 0.5 * ln((1 + x) / (1 - x)), which
+    reshapes the values into a nearly Gaussian distribution. Turning
+    points show up as sharp, clearly defined peaks, often one bar earlier
+    than in RSI or Stochastic. 'signal' is the fisher value of the
+    previous bar; a cross of 'fisher' through 'signal' at an extreme is
+    the classic reversal trigger.
+    Returns: dict of lists of floats = jhta.FISHER(df, n=9, high='High', low='Low')
+    with keys 'fisher' and 'signal'
+    Source: https://www.mesasoftware.com/papers/UsingTheFisherTransform.pdf
+    """
+    fisher_dict = {'fisher': [], 'signal': []}
+    mid_list = []
+    for i in range(len(df[high])):
+        mid_list.append((df[high][i] + df[low][i]) / 2)
+    value = 0.0
+    fisher = 0.0
+    for i in range(len(df[high])):
+        if i + 1 < n:
+            fisher_dict['fisher'].append(float('NaN'))
+            fisher_dict['signal'].append(float('NaN'))
+        else:
+            start = i + 1 - n
+            end = i + 1
+            max_h = max(mid_list[start:end])
+            min_l = min(mid_list[start:end])
+            if max_h - min_l == 0:
+                raw = 0.0
+            else:
+                raw = (mid_list[i] - min_l) / (max_h - min_l) - .5
+            # smooth and clamp the normalized value to avoid ln() blowing up:
+            value = .66 * raw + .67 * value
+            if value > .99:
+                value = .999
+            elif value < -.99:
+                value = -.999
+            signal = fisher
+            fisher = .5 * math.log((1 + value) / (1 - value)) + .5 * fisher
+            fisher_dict['fisher'].append(fisher)
+            fisher_dict['signal'].append(signal)
+    return fisher_dict


### PR DESCRIPTION
True Strength Index: William Blau's double EMA-smoothed momentum oscillator scaled to -100..+100 plus a signal line.

Theory: smoothing 1-bar momentum twice (n_long then n_short) and dividing by the double smoothed absolute momentum yields an RSI-like oscillator with far less noise; zero line shows control, signal crosses give entries.
Returns: dict of lists of floats ('tsi', 'signal')
Source: https://school.stockcharts.com/doku.php?id=technical_indicators:true_strength_index

### Review notes
- Single-indicator change, one file, one commit.
- Pure Python; smoke-tested on synthetic OHLCV with warm-up assertions.
