### PR TITLE
Implement ADXR (Average Directional Movement Index Rating - measures trend s)

### DIFF
--- a/jhtalib/momentum_indicators/momentum_indicators.py
+++ b/jhtalib/momentum_indicators/momentum_indicators.py
@@ -12,10 +12,86 @@ def ADX(df, n):
     Average Directional Movement Index
     """
 
-def ADXR(df, n):
+def ADXR(df, n, high='High', low='Low', close='Close'):
     """
-    Average Directional Movement Index Rating
+    Average Directional Movement Index Rating - measures trend strength momentum by averaging the current ADX with the ADX from n periods ago
+    Theory: ADXR = (ADX_today + ADX_n_periods_ago) / 2. ADX is built from
+            Wilder-smoothed True Range and +DM/-DM: +DI = 100 * smoothed(+DM) / smoothed(TR),
+            -DI = 100 * smoothed(-DM) / smoothed(TR), DX = 100 * |+DI - -DI| / (+DI + -DI),
+            and ADX is the Wilder-smoothed DX (first ADX = mean of first n DX values).
+            Rising ADXR signals strengthening trend; falling ADXR signals a weakening trend.
+    Returns: list of floats = jhta.ADXR(df, n, high='High', low='Low', close='Close')
+    Source: J. Welles Wilder Jr., New Concepts in Technical Trading Systems (1978); https://www.fmlabs.com/reference/default.htm?url=ADXR.htm
     """
+    highs = df[high]
+    lows = df[low]
+    closes = df[close]
+    length = len(closes)
+
+    # True Range, +DM, -DM (defined from the second bar onward)
+    tr_list = [float('NaN')]
+    pdm_list = [float('NaN')]
+    mdm_list = [float('NaN')]
+    for i in range(1, length):
+        tr = max(highs[i] - lows[i], abs(highs[i] - closes[i - 1]), abs(lows[i] - closes[i - 1]))
+        up_move = highs[i] - highs[i - 1]
+        down_move = lows[i - 1] - lows[i]
+        pdm = up_move if (up_move > down_move and up_move > 0) else .0
+        mdm = down_move if (down_move > up_move and down_move > 0) else .0
+        tr_list.append(tr)
+        pdm_list.append(pdm)
+        mdm_list.append(mdm)
+
+    # Wilder smoothing of TR, +DM, -DM and the resulting DX series
+    dx_list = [float('NaN')] * length
+    smoothed_tr = .0
+    smoothed_pdm = .0
+    smoothed_mdm = .0
+    for i in range(1, length):
+        if i < n:
+            continue
+        if i == n:
+            smoothed_tr = sum(tr_list[1:n + 1])
+            smoothed_pdm = sum(pdm_list[1:n + 1])
+            smoothed_mdm = sum(mdm_list[1:n + 1])
+        else:
+            smoothed_tr = smoothed_tr - smoothed_tr / n + tr_list[i]
+            smoothed_pdm = smoothed_pdm - smoothed_pdm / n + pdm_list[i]
+            smoothed_mdm = smoothed_mdm - smoothed_mdm / n + mdm_list[i]
+        if smoothed_tr != 0:
+            pdi = 100 * smoothed_pdm / smoothed_tr
+            mdi = 100 * smoothed_mdm / smoothed_tr
+        else:
+            pdi = .0
+            mdi = .0
+        di_sum = pdi + mdi
+        dx_list[i] = 100 * abs(pdi - mdi) / di_sum if di_sum != 0 else .0
+
+    # ADX: first value = mean of first n DX values, then Wilder-smoothed
+    adx_list = [float('NaN')] * length
+    adx = float('NaN')
+    for i in range(length):
+        if i + 1 < 2 * n:
+            continue
+        if i + 1 == 2 * n:
+            adx = sum(dx_list[n:2 * n]) / n
+        else:
+            adx = (adx * (n - 1) + dx_list[i]) / n
+        adx_list[i] = adx
+
+    # ADXR = average of current ADX and ADX from n periods ago
+    adxr_list = []
+    for i in range(length):
+        if i < n:
+            adxr_list.append(float('NaN'))
+            continue
+        current_adx = adx_list[i]
+        past_adx = adx_list[i - n]
+        if current_adx != current_adx or past_adx != past_adx:
+            adxr_list.append(float('NaN'))
+        else:
+            adxr_list.append((current_adx + past_adx) / 2)
+    return adxr_list
 
 def APO(df, n_fast, n_slow, price='Close'):
     """


### PR DESCRIPTION
Implements `ADXR` — Average Directional Movement Index Rating - measures trend strength momentum by averaging the current ADX with the ADX from n periods ago

**Theory:** ADXR = (ADX_today + ADX_n_periods_ago) / 2. ADX is built from

**Returns:** list of floats = jhta.ADXR(df, n, high='High', low='Low', close='Close')

**Source:** J. Welles Wilder Jr., New Concepts in Technical Trading Systems (1978); https://www.fmlabs.com/reference/default.htm?url=ADXR.htm

### Review notes
- Single-indicator change: only `ADXR` (implements the existing stub in place).
- Pure Python (stdlib only), NaN warm-up handling, jhTAlib parameter conventions.
- Compiles clean; smoke-tested on 120 bars of synthetic OHLCV: `pass:list[120]`.
