### PR TITLE
Add polynomial_features module: POLYNOMIAL_FORECAST, POLYNOMIAL_RESIDUAL, POLYNOMIAL_TREND

### DIFF
--- a/jhtalib/polynomial_features/__init__.py
+++ b/jhtalib/polynomial_features/__init__.py
@@ -1,0 +1,1 @@
+from .polynomial_features import *

--- a/jhtalib/polynomial_features/polynomial_features.py
+++ b/jhtalib/polynomial_features/polynomial_features.py
@@ -1,0 +1,222 @@
+""""""
+# Import Built-Ins:
+
+# Import Third-Party:
+
+# Import Homebrew:
+import jhtalib as jhta
+
+
+def POLYNOMIAL_FORECAST(df, n, price='Close', degree=2, steps_ahead=1):
+    """
+    Polynomial Forecast - rolling least-squares polynomial fit extrapolated steps_ahead bars beyond the window end
+    Theory: for each bar the trailing n prices are fitted with a polynomial of the given degree
+            (x = 0..n-1) by ordinary least squares, solving the normal equations A c = b with
+            A[j][k] = sum(x^(j+k)) and b[j] = sum(x^j * y) via Gaussian elimination with partial
+            pivoting. The fitted polynomial is then evaluated at x = n-1+steps_ahead, projecting
+            the recent trend curve forward. In simple terms: it draws the best-fitting curve
+            through the last n prices and extends that curve into the future to estimate where
+            price would land if the current trend shape simply continued. Extrapolation grows
+            less reliable as steps_ahead or degree increases. The first n-1 values are NaN
+            (warm-up); n must exceed degree, otherwise all values are NaN.
+    Returns: list of floats = jhta.POLYNOMIAL_FORECAST(df, n, price='Close', degree=2, steps_ahead=1)
+    Source: Legendre, A. M. (1805). Nouvelles methodes pour la determination des orbites des
+            cometes (method of least squares); https://en.wikipedia.org/wiki/Polynomial_regression
+    """
+    prices = df[price]
+    m = degree + 1
+    forecast_list = []
+    for i in range(len(prices)):
+        if i + 1 < n or n < m:
+            forecast_list.append(float('NaN'))
+            continue
+        window = prices[i + 1 - n:i + 1]
+        # build normal equations A c = b
+        a = [[0.0] * m for _ in range(m)]
+        b = [0.0] * m
+        for x in range(n):
+            y = window[x]
+            xpow = [1.0]
+            for _ in range(2 * degree):
+                xpow.append(xpow[-1] * x)
+            for j in range(m):
+                b[j] += xpow[j] * y
+                for kk in range(m):
+                    a[j][kk] += xpow[j + kk]
+        # Gaussian elimination with partial pivoting
+        singular = False
+        for col in range(m):
+            piv = col
+            for row in range(col + 1, m):
+                if abs(a[row][col]) > abs(a[piv][col]):
+                    piv = row
+            if abs(a[piv][col]) < 1e-12:
+                singular = True
+                break
+            a[col], a[piv] = a[piv], a[col]
+            b[col], b[piv] = b[piv], b[col]
+            for row in range(col + 1, m):
+                factor = a[row][col] / a[col][col]
+                for kk in range(col, m):
+                    a[row][kk] -= factor * a[col][kk]
+                b[row] -= factor * b[col]
+        if singular:
+            forecast_list.append(float('NaN'))
+            continue
+        # back substitution
+        c = [0.0] * m
+        for j in range(m - 1, -1, -1):
+            s = b[j]
+            for kk in range(j + 1, m):
+                s -= a[j][kk] * c[kk]
+            c[j] = s / a[j][j]
+        # evaluate polynomial at x = n-1+steps_ahead (Horner)
+        x_fc = float(n - 1 + steps_ahead)
+        forecast = c[m - 1]
+        for j in range(m - 2, -1, -1):
+            forecast = forecast * x_fc + c[j]
+        forecast_list.append(forecast)
+    return forecast_list
+
+def POLYNOMIAL_RESIDUAL(df, n, price='Close', degree=2):
+    """
+    Polynomial Residual - actual price minus the rolling least-squares polynomial trend value at each window end
+    Theory: for each bar the trailing n prices are fitted with a polynomial of the given degree
+            (x = 0..n-1) by ordinary least squares, solving the normal equations A c = b with
+            A[j][k] = sum(x^(j+k)) and b[j] = sum(x^j * y) via Gaussian elimination with partial
+            pivoting. The residual is the actual price minus the fitted polynomial evaluated at
+            the window end (x = n-1). In simple terms: it measures how far today's price sits
+            above (positive) or below (negative) its own recent best-fit curve, so it isolates
+            the short-term noise or displacement around the underlying trend. Large residuals can
+            flag overextension relative to the trend. The first n-1 values are NaN (warm-up);
+            n must exceed degree, otherwise all values are NaN.
+    Returns: list of floats = jhta.POLYNOMIAL_RESIDUAL(df, n, price='Close', degree=2)
+    Source: Legendre, A. M. (1805). Nouvelles methodes pour la determination des orbites des
+            cometes (method of least squares); https://en.wikipedia.org/wiki/Polynomial_regression
+    """
+    prices = df[price]
+    m = degree + 1
+    residual_list = []
+    for i in range(len(prices)):
+        if i + 1 < n or n < m:
+            residual_list.append(float('NaN'))
+            continue
+        window = prices[i + 1 - n:i + 1]
+        # build normal equations A c = b
+        a = [[0.0] * m for _ in range(m)]
+        b = [0.0] * m
+        for x in range(n):
+            y = window[x]
+            xpow = [1.0]
+            for _ in range(2 * degree):
+                xpow.append(xpow[-1] * x)
+            for j in range(m):
+                b[j] += xpow[j] * y
+                for kk in range(m):
+                    a[j][kk] += xpow[j + kk]
+        # Gaussian elimination with partial pivoting
+        singular = False
+        for col in range(m):
+            piv = col
+            for row in range(col + 1, m):
+                if abs(a[row][col]) > abs(a[piv][col]):
+                    piv = row
+            if abs(a[piv][col]) < 1e-12:
+                singular = True
+                break
+            a[col], a[piv] = a[piv], a[col]
+            b[col], b[piv] = b[piv], b[col]
+            for row in range(col + 1, m):
+                factor = a[row][col] / a[col][col]
+                for kk in range(col, m):
+                    a[row][kk] -= factor * a[col][kk]
+                b[row] -= factor * b[col]
+        if singular:
+            residual_list.append(float('NaN'))
+            continue
+        # back substitution
+        c = [0.0] * m
+        for j in range(m - 1, -1, -1):
+            s = b[j]
+            for kk in range(j + 1, m):
+                s -= a[j][kk] * c[kk]
+            c[j] = s / a[j][j]
+        # evaluate polynomial at window end x = n-1 (Horner)
+        x_end = float(n - 1)
+        fitted = c[m - 1]
+        for j in range(m - 2, -1, -1):
+            fitted = fitted * x_end + c[j]
+        residual_list.append(window[n - 1] - fitted)
+    return residual_list
+
+def POLYNOMIAL_TREND(df, n, price='Close', degree=2):
+    """
+    Polynomial Trend - rolling least-squares polynomial fit of price against time, returning the fitted value at each window end
+    Theory: for each bar the trailing n prices are fitted with a polynomial of the given degree
+            (x = 0..n-1) by ordinary least squares. The coefficients solve the normal equations
+            A c = b with A[j][k] = sum(x^(j+k)) and b[j] = sum(x^j * y), solved here by Gaussian
+            elimination with partial pivoting. The returned value is the polynomial evaluated at
+            the window end (x = n-1), i.e. the smoothed trend value for the current bar. In simple
+            terms: it draws the best-fitting curve through the last n prices and reports where
+            that curve sits today, filtering out bar-to-bar noise. degree=1 gives a straight
+            trendline, degree=2 captures curvature (acceleration/deceleration of the trend).
+            The first n-1 values are NaN (warm-up); n must exceed degree, otherwise all values
+            are NaN.
+    Returns: list of floats = jhta.POLYNOMIAL_TREND(df, n, price='Close', degree=2)
+    Source: Legendre, A. M. (1805). Nouvelles methodes pour la determination des orbites des
+            cometes (method of least squares); https://en.wikipedia.org/wiki/Polynomial_regression
+    """
+    prices = df[price]
+    m = degree + 1
+    trend_list = []
+    for i in range(len(prices)):
+        if i + 1 < n or n < m:
+            trend_list.append(float('NaN'))
+            continue
+        window = prices[i + 1 - n:i + 1]
+        # build normal equations A c = b
+        a = [[0.0] * m for _ in range(m)]
+        b = [0.0] * m
+        for x in range(n):
+            y = window[x]
+            xpow = [1.0]
+            for _ in range(2 * degree):
+                xpow.append(xpow[-1] * x)
+            for j in range(m):
+                b[j] += xpow[j] * y
+                for kk in range(m):
+                    a[j][kk] += xpow[j + kk]
+        # Gaussian elimination with partial pivoting
+        singular = False
+        for col in range(m):
+            piv = col
+            for row in range(col + 1, m):
+                if abs(a[row][col]) > abs(a[piv][col]):
+                    piv = row
+            if abs(a[piv][col]) < 1e-12:
+                singular = True
+                break
+            a[col], a[piv] = a[piv], a[col]
+            b[col], b[piv] = b[piv], b[col]
+            for row in range(col + 1, m):
+                factor = a[row][col] / a[col][col]
+                for kk in range(col, m):
+                    a[row][kk] -= factor * a[col][kk]
+                b[row] -= factor * b[col]
+        if singular:
+            trend_list.append(float('NaN'))
+            continue
+        # back substitution
+        c = [0.0] * m
+        for j in range(m - 1, -1, -1):
+            s = b[j]
+            for kk in range(j + 1, m):
+                s -= a[j][kk] * c[kk]
+            c[j] = s / a[j][j]
+        # evaluate polynomial at window end x = n-1 (Horner)
+        x_end = float(n - 1)
+        fitted = c[m - 1]
+        for j in range(m - 2, -1, -1):
+            fitted = fitted * x_end + c[j]
+        trend_list.append(fitted)
+    return trend_list


### PR DESCRIPTION
One coherent module in a single conflict-free review (the earlier per-function PRs each created the same file and would conflict after the first merge; they are closed with a pointer here).

**Functions:**
- `POLYNOMIAL_FORECAST` — Least-squares polynomial extrapolation: fit the degree-d polynomial to the trailing n bars by OLS (normal equations), then evaluate the fitt
- `POLYNOMIAL_RESIDUAL` — In-sample OLS residual of the degree-d polynomial fit: e(n-1) = y_actual(n-1) - yhat(n-1), where yhat is the least-squares polynomial (same 
- `POLYNOMIAL_TREND` — Legendre (1805) ordinary least-squares polynomial regression. Over the trailing n bars with abscissa x=0..n-1, fit y(x)=c0+c1 x+...+c_d x^d 

### Review notes
- Self-contained new module directory; `jhtalib/__init__.py` is NOT touched — all module PRs merge conflict-free in any order.
- Registration of the import lines is bundled in the separate 'register new modules' PR (merge last; drop lines for unmerged modules).
- Pure Python (stdlib only), NaN warm-up handling, docstrings with Theory/Returns/Source, per-function known-value verification.